### PR TITLE
Refinar tela de onboarding do convite

### DIFF
--- a/Macro/Macro/Model/Enum/EnumImageName.swift
+++ b/Macro/Macro/Model/Enum/EnumImageName.swift
@@ -12,5 +12,8 @@ enum EnumImageName: String {
     case squirrels = "esquilos"
     case squirrel = "esquilo"
     case invitePhone = "celular"
+    case sharedPhone = "celular-compartilhar"
+    case connectedPhone = "celular-conectados"
+    case confirmationPhone = "celular-confirmacao"
     case doubleSquirrels = "DuplaEsquilos"
 }

--- a/Macro/Macro/Model/Enum/EnumOnBoardingText.swift
+++ b/Macro/Macro/Model/Enum/EnumOnBoardingText.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum OnBoardingText: String {
+    
     case titleFirstScreen = "Conquiste os seus objetivos"
     case firstScreen = "Crie metas e controle gastos com quem você ama"
     
@@ -20,4 +21,12 @@ enum OnBoardingText: String {
     case titleInviteScreen = "Envie um convite"
     case inviteScreen = "Compartilhe o link com quem ama para dividirem seus gastos e metas juntos"
     
+    case titleShareScreen = "Aguarde o convite do seu parceiro"
+    case shareScreen = "Agora o seu parceiro deve te enviar um convite semelhante ao que você enviou"
+    
+    case titleConfirmationScreen = "Envie um convite de confirmação ao seu parceiro"
+    case confirmationScreen = "Após o envio do convite, vocês estarão conectados"
+    
+    case titleConnectedScreen = "Agora vocês estão conectados"
+    case connectedScreen = "Já podem iniciar as suas metas e dividirem seus gastos"
 }

--- a/Macro/Macro/Model/OnBoarding.swift
+++ b/Macro/Macro/Model/OnBoarding.swift
@@ -19,8 +19,8 @@ struct OnBoarding: Identifiable, Hashable, Equatable {
         OnBoarding(imageName: EnumImageName.squirrels.rawValue, title: OnBoardingText.titleSecondScreen.rawValue, description: OnBoardingText.secondScreen.rawValue, tag: 1),
         OnBoarding(imageName: EnumImageName.squirrel.rawValue, title: OnBoardingText.titleIncomeScreen.rawValue, description: OnBoardingText.incomeScreen.rawValue, tag: 2),
         OnBoarding(imageName: EnumImageName.invitePhone.rawValue, title: OnBoardingText.titleInviteScreen.rawValue, description: OnBoardingText.inviteScreen.rawValue, tag: 3),
-        OnBoarding(imageName: EnumImageName.invitePhone.rawValue, title: OnBoardingText.titleShareScreen.rawValue, description: OnBoardingText.shareScreen.rawValue, tag: 4),
-        OnBoarding(imageName: EnumImageName.invitePhone.rawValue, title: OnBoardingText.titleConfirmationScreen.rawValue, description: OnBoardingText.confirmationScreen.rawValue, tag: 5),
-        OnBoarding(imageName: EnumImageName.invitePhone.rawValue, title: OnBoardingText.titleConnectedScreen.rawValue, description: OnBoardingText.connectedScreen.rawValue, tag: 6)
+        OnBoarding(imageName: EnumImageName.sharedPhone.rawValue, title: OnBoardingText.titleShareScreen.rawValue, description: OnBoardingText.shareScreen.rawValue, tag: 4),
+        OnBoarding(imageName: EnumImageName.confirmationPhone.rawValue, title: OnBoardingText.titleConfirmationScreen.rawValue, description: OnBoardingText.confirmationScreen.rawValue, tag: 5),
+        OnBoarding(imageName: EnumImageName.connectedPhone.rawValue, title: OnBoardingText.titleConnectedScreen.rawValue, description: OnBoardingText.connectedScreen.rawValue, tag: 6)
     ]
 }

--- a/Macro/Macro/Model/OnBoarding.swift
+++ b/Macro/Macro/Model/OnBoarding.swift
@@ -19,8 +19,8 @@ struct OnBoarding: Identifiable, Hashable, Equatable {
         OnBoarding(imageName: EnumImageName.squirrels.rawValue, title: OnBoardingText.titleSecondScreen.rawValue, description: OnBoardingText.secondScreen.rawValue, tag: 1),
         OnBoarding(imageName: EnumImageName.squirrel.rawValue, title: OnBoardingText.titleIncomeScreen.rawValue, description: OnBoardingText.incomeScreen.rawValue, tag: 2),
         OnBoarding(imageName: EnumImageName.invitePhone.rawValue, title: OnBoardingText.titleInviteScreen.rawValue, description: OnBoardingText.inviteScreen.rawValue, tag: 3),
-        OnBoarding(imageName: EnumImageName.invitePhone.rawValue, title: "Esperando confirmação", description: "Seu parceiro irá mandar um link de confirmação para você", tag: 4),
-        OnBoarding(imageName: EnumImageName.invitePhone.rawValue, title: "Envie a confirmação", description: "compartilhe com seu parceiro o link de confirmação", tag: 5),
-        OnBoarding(imageName: EnumImageName.invitePhone.rawValue, title: "Tudo Certo!", description: "Você está conectado com seu parceiro", tag: 6)
+        OnBoarding(imageName: EnumImageName.invitePhone.rawValue, title: OnBoardingText.titleShareScreen.rawValue, description: OnBoardingText.shareScreen.rawValue, tag: 4),
+        OnBoarding(imageName: EnumImageName.invitePhone.rawValue, title: OnBoardingText.titleConfirmationScreen.rawValue, description: OnBoardingText.confirmationScreen.rawValue, tag: 5),
+        OnBoarding(imageName: EnumImageName.invitePhone.rawValue, title: OnBoardingText.titleConnectedScreen.rawValue, description: OnBoardingText.connectedScreen.rawValue, tag: 6)
     ]
 }

--- a/Macro/Macro/View/Home/elements/CarouselView.swift
+++ b/Macro/Macro/View/Home/elements/CarouselView.swift
@@ -41,7 +41,7 @@ struct CarouselView: View {
 
 struct CarouselView_Previews: PreviewProvider {
     static var previews: some View {
-        CarouselView (width: 325.0, heigth: 200.0, goals: .constant([
+        CarouselView(width: 325.0, heigth: 200.0, goals: .constant([
              Goal(title: "Carro Novo", value: 20000, weeks: 48, motivation: "Realização de um sonho", priority: 1, methodologyGoal: MethodologyGoal(weeks: 52, crescent: true)),
              Goal(title: "Carro Novo", value: 20000, weeks: 48, motivation: "Realização de um sonho", priority: 1, methodologyGoal: MethodologyGoal(weeks: 52, crescent: true)),
              Goal(title: "Carro Novo", value: 20000, weeks: 48, motivation: "Realização de um sonho", priority: 1, methodologyGoal: MethodologyGoal(weeks: 52, crescent: true))


### PR DESCRIPTION
Aceitando esse PR, a dev terá as ilustrações e textos faltantes no OnBoarding, para que assim o usuário entenda o fluxo de compartilhamento de convite.